### PR TITLE
Fixed notice of undefined $result.

### DIFF
--- a/includes/class-wc-stripe-customer.php
+++ b/includes/class-wc-stripe-customer.php
@@ -174,7 +174,7 @@ class WC_Stripe_Customer {
 		), 'customers/' . $this->get_id() . '/sources' );
 
 		if ( is_wp_error( $response ) ) {
-			if ( 'customer' === $result->get_error_code() && $retry ) {
+			if ( 'customer' === $response->get_error_code() && $retry ) {
 				$this->create_customer();
 				return $this->add_card( $token, false );
 			} else {


### PR DESCRIPTION
Fixes #5.

#### Changes proposed in this Pull Request:
- Uses `$responses` instead of `$result` which is undefined

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
