### PR TITLE
Prompt, via admin notice, to set API keys if not set.

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -159,6 +159,18 @@ class WC_Stripe {
 				unset( $_GET['activate'] );
 			}
 		}
+
+		// Check if secret key present. Otherwise prompt, via notice, to go to
+		// setting.
+		if ( ! class_exists( 'WC_Stripe_API' ) ) {
+			include_once( plugin_basename( 'includes/class-wc-stripe-api.php' ) );
+		}
+
+		$secret = WC_Stripe_API::get_secret_key();
+		if ( empty( $secret ) ) {
+			$setting_link = $this->get_setting_link();
+			$this->add_admin_notice( 'prompt_connect', 'notice notice-warning', __( 'Stripe is almost ready. To get started, <a href="' . $setting_link . '">set your Stripe account keys</a>.', 'wwoocommerce-gateway-stripe' ) );
+		}
 	}
 
 	/**
@@ -200,12 +212,29 @@ class WC_Stripe {
 	 * @since 1.0.0
 	 */
 	public function plugin_action_links( $links ) {
+		$setting_link = $this->get_setting_link();
+
 		$plugin_links = array(
-			'<a href="' . admin_url( 'admin.php?page=wc-settings&tab=checkout&section=stripe' ) . '">' . __( 'Settings', 'woocommerce-gateway-stripe' ) . '</a>',
+			'<a href="' . $setting_link . '">' . __( 'Settings', 'woocommerce-gateway-stripe' ) . '</a>',
 			'<a href="https://docs.woothemes.com/document/stripe/">' . __( 'Docs', 'woocommerce-gateway-stripe' ) . '</a>',
 			'<a href="http://support.woothemes.com/">' . __( 'Support', 'woocommerce-gateway-stripe' ) . '</a>',
 		);
 		return array_merge( $plugin_links, $links );
+	}
+
+	/**
+	 * Get setting link.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return string Setting link
+	 */
+	public function get_setting_link() {
+		$use_id_as_section = version_compare( WC()->version, '2.6', '>=' );
+
+		$section_slug = $use_id_as_section ? 'stripe' : strtolower( 'WC_Gateway_Stripe' );
+
+		return admin_url( 'admin.php?page=wc-settings&tab=checkout&section=' . $section_slug );
 	}
 
 	/**

--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -242,7 +242,7 @@ class WC_Stripe {
 	 */
 	public function admin_notices() {
 		foreach ( (array) $this->notices as $notice_key => $notice ) {
-			echo "<div class='" . esc_attr( sanitize_html_class( $notice['class'] ) ) . "'><p>";
+			echo "<div class='" . esc_attr( $notice['class'] ) . "'><p>";
 			echo wp_kses( $notice['message'], array( 'a' => array( 'href' => array() ) ) );
 			echo "</p></div>";
 		}


### PR DESCRIPTION
Fixes #3.

#### Changes proposed in this Pull Request:
- Add admin notice globally when secret key is empty. This acts as CTA for merchant when choosing Stripe via on-boarding wizard.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
