### PR TITLE
Added missing order note when charge is complete.

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -511,7 +511,11 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 
 		if ( $response->captured ) {
 			$order->payment_complete( $response->id );
-			WC_Stripe::log( "Successful charge: $response->id" );
+
+			$message = sprintf( __( 'Stripe charge complate (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $response->id );
+			$order->add_order_note( $message );
+			WC_Stripe::log( 'Success: ' . $message );
+
 		} else {
 			add_post_meta( $order->id, '_transaction_id', $response->id, true );
 


### PR DESCRIPTION
Fixes #18.

#### Changes proposed in this Pull Request:
- Add order note when charge is complete

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.
