### PR TITLE
Fix payment methods not showing up

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -453,6 +453,38 @@ class WC_Stripe {
 			error_log( $message );
 		}
 	}
+	/**
+	 * Gets saved tokens from API if they don't already exist in WooCommerce.
+	 * @param array $tokens
+	 * @return array
+	 */
+	public function woocommerce_get_customer_payment_tokens( $tokens, $customer_id, $gateway_id ) {
+		if ( is_user_logged_in() && 'stripe' === $gateway_id && class_exists( 'WC_Payment_Token_CC' ) ) {
+			$stripe_customer = new WC_Stripe_Customer( $customer_id );
+			$stripe_cards    = $stripe_customer->get_cards();
+			$stored_tokens   = array();
+
+			foreach ( $tokens as $token ) {
+				$stored_tokens[] = $token->get_token();
+			}
+
+			foreach ( $stripe_cards as $card ) {
+				if ( ! in_array( $card->id, $stored_tokens ) ) {
+					$token = new WC_Payment_Token_CC();
+					$token->set_token( $card->id );
+					$token->set_gateway_id( 'stripe' );
+					$token->set_card_type( strtolower( $card->brand ) );
+					$token->set_last4( $card->last4 );
+					$token->set_expiry_month( $card->exp_month  );
+					$token->set_expiry_year( $card->exp_year );
+					$token->set_user_id( $customer_id );
+					$token->save();
+					$tokens[ $token->get_id() ] = $token;
+				}
+			}
+		}
+		return $tokens;
+	}
 }
 
 $GLOBALS['wc_stripe'] = WC_Stripe::get_instance();


### PR DESCRIPTION
Fixes #19 .

#### Changes proposed in this Pull Request:
- Add a missing method to a class. This method is referenced in a filter but can't be reached so the filter returns a null value resulting in a blank payment methods page.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.

