### PR TITLE
Remove renewal payment retry

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -601,7 +601,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 		if ( $response->captured ) {
 			$order->payment_complete( $response->id );
 
-			$message = sprintf( __( 'Stripe charge complate (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $response->id );
+			$message = sprintf( __( 'Stripe charge complete (Charge ID: %s)', 'woocommerce-gateway-stripe' ), $response->id );
 			$order->add_order_note( $message );
 			WC_Stripe::log( 'Success: ' . $message );
 


### PR DESCRIPTION
Fixes #37

#### Changes proposed in this Pull Request:

This patch removes the renewal payment retry system introduced with SHA: fb1cdf410 which would delete the card and potentially the customer tokens from a renewal order and use the tokens on the customer's account instead. This lead to issues outlined in #37.

It also sneaks in a typo fix with SHA: 90ff54830

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.