### PR TITLE
Notice Message Upon Activation if WC not Active Fix

### DIFF
--- a/woocommerce-gateway-stripe.php
+++ b/woocommerce-gateway-stripe.php
@@ -202,6 +202,10 @@ class WC_Stripe {
 			}
 			return sprintf( $message, WC_STRIPE_MIN_PHP_VER, phpversion() );
 		}
+		
+		if ( ! defined( 'WC_VERSION' ) ) {
+			return __( 'The plugin could not be activated. WooCommerce is not activated.', 'woocommerce-gateway-stripe' );
+		} 
 
 		if ( version_compare( WC_VERSION, WC_STRIPE_MIN_WC_VER, '<' ) ) {
 			if ( $during_activation ) {


### PR DESCRIPTION
Fixes #28 

#### Changes proposed in this Pull Request:
- This patch removes the error notice when trying to enabling Stipe plugin when WooCommerce is **not** activated.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [ ] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.


