### PR TITLE
Remove bitcoin icon when using Stripe checkout as its not supported c…

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 
 = For newer changelog entries, see readme.txt =
 
-= 3.0.3 - 2016.xx.xx =
+= 3.1.0 - 2016.xx.xx =
 * Fix - Remove bitcoin icon when not using Stripe Checkout mode as it is not supported.
 
 = 3.0.2 - 2016.06.14 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,9 @@
 
 = For newer changelog entries, see readme.txt =
 
+= 3.0.3 - 2016.xx.xx =
+* Fix - Remove bitcoin icon when not using Stripe Checkout mode as it is not supported.
+
 = 3.0.2 - 2016.06.14 =
 * Fix - Set empty array as default value for first argument in WC_Stripe_Customer::create_customer
 * Tweak - Update default title to make it consistent with existing titles

--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -164,7 +164,7 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 			$icon .= '<img src="' . WC_HTTPS::force_https_url( WC()->plugin_url() . '/assets/images/icons/credit-cards/diners' . $ext ) . '" alt="Diners" width="32" ' . $style . ' />';
 		}
 
-		if ( $this->bitcoin ) {
+		if ( 'yes' === $this->bitcoin && 'yes' === $this->stripe_checkout ) {
 			$icon .= '<img src="' . WC_HTTPS::force_https_url( plugins_url( '/assets/images/bitcoin' . $ext, WC_STRIPE_MAIN_FILE ) ) . '" alt="Bitcoin" width="32" ' . $style . ' />';
 		}
 


### PR DESCRIPTION
Fixes #25

cc @gedex for review.

#### Changes proposed in this Pull Request:
* Fix - Remove bitcoin icon when not using Stripe Checkout mode as it is not supported.

-------------------
- [x] Make sure your changes respect [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/).
- [x] Did you make changes, or create a **new .js file**? If **Gruntfile.js** exists in the repo, make sure to run `grunt`.


…loses #25