### PR TITLE
Secure Live Secret API key

### DIFF
--- a/includes/class-wc-gateway-stripe.php
+++ b/includes/class-wc-gateway-stripe.php
@@ -122,7 +122,8 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 		$this->stripe_checkout_locale = $this->get_option( 'stripe_checkout_locale' );
 		$this->stripe_checkout_image  = $this->get_option( 'stripe_checkout_image', '' );
 		$this->saved_cards            = 'yes' === $this->get_option( 'saved_cards' );
-		$this->secret_key             = $this->testmode ? $this->get_option( 'test_secret_key' ) : $this->get_option( 'secret_key' );
+		$this->secret_key             = $this->get_option( 'secret_key' );
+		$this->test_secret_key        = $this->get_option( 'test_secret_key' );
 		$this->publishable_key        = $this->testmode ? $this->get_option( 'test_publishable_key' ) : $this->get_option( 'publishable_key' );
 		$this->bitcoin                = 'USD' === strtoupper( get_woocommerce_currency() ) && 'yes' === $this->get_option( 'stripe_bitcoin' );
 		$this->logging                = 'yes' === $this->get_option( 'logging' );
@@ -131,7 +132,16 @@ class WC_Gateway_Stripe extends WC_Payment_Gateway_CC {
 			$this->order_button_text = __( 'Continue to payment', 'woocommerce-gateway-stripe' );
 		}
 
+		foreach ( $this->form_fields as $field_key => $values ) {
+			if( isset( $values['secure'] ) && $values['secure'] ) {
+				$secure_value = apply_filters( 'woocommerce_settings_api_secure_field_get', $this->$field_key, $this->id, $field_key );
+				$this->settings[$field_key] = $secure_value;
+				$this->$field_key = $secure_value;
+			}
+		}
+
 		if ( $this->testmode ) {
+			$this->secret_key = $this->test_secret_key;
 			$this->description .= ' ' . sprintf( __( 'TEST MODE ENABLED. In test mode, you can use the card number 4242424242424242 with any CVC and a valid expiration date or check the documentation "<a href="%s">Testing Stripe</a>" for more card numbers.', 'woocommerce-gateway-stripe' ), 'https://stripe.com/docs/testing' );
 			$this->description  = trim( $this->description );
 		}

--- a/includes/class-wc-stripe-api.php
+++ b/includes/class-wc-stripe-api.php
@@ -38,7 +38,7 @@ class WC_Stripe_API {
 			$options = get_option( 'woocommerce_stripe_settings' );
 
 			if ( isset( $options['testmode'], $options['secret_key'], $options['test_secret_key'] ) ) {
-				self::set_secret_key( 'yes' === $options['testmode'] ? $options['test_secret_key'] : $options['secret_key'] );
+				self::set_secret_key( 'yes' === $options['testmode'] ? $options['test_secret_key'] : apply_filters( 'woocommerce_settings_api_secure_field_get', $options['secret_key'], 'stripe', 'secret_key' ) );
 			}
 		}
 		return self::$secret_key;

--- a/includes/settings-stripe.php
+++ b/includes/settings-stripe.php
@@ -40,6 +40,7 @@ return apply_filters( 'wc_stripe_settings',
 			'description' => __( 'Get your API keys from your stripe account.', 'woocommerce-gateway-stripe' ),
 			'default'     => '',
 			'desc_tip'    => true,
+			'secure'			=> true,
 		),
 		'publishable_key' => array(
 			'title'       => __( 'Live Publishable Key', 'woocommerce-gateway-stripe' ),


### PR DESCRIPTION
As laid out in Issue #65 this allows for the live_secure_key to be declared as secure and allow it to be secured prior to storage and use.

In doing this patch, I broke out the test_secret_key and secret_key into two separate strings instead of in one ternary operator for secret_key. This is because the logic for the filter just seemed a bit too much for that one line.

I provided code that does a foreach on the settings fields to look for secure fields. Since we declare only the secret_key secure we can reduce that to a line of the filter with the specifics for the secret_key. This was just a good generic code for running the filter but if it's too verbose we can change it up.